### PR TITLE
feat: apply tiered tower vision radii

### DIFF
--- a/lol-board/src/components/ControlPanel.jsx
+++ b/lol-board/src/components/ControlPanel.jsx
@@ -28,6 +28,9 @@ const ControlPanel = ({
   calMode,
   towerVisionRadius,
   setTowerVisionRadius,
+  towerCalibType,
+  setTowerCalibType,
+  towerTypeLabels,
   tokenVisionRadius,
   setTokenVisionRadius,
   wardRadius,
@@ -227,21 +230,43 @@ const ControlPanel = ({
                 Calibrer tour
               </button>
             </div>
-            <p className="text-xs text-slate-400">
-              Clique <b>centre</b> puis <b>bord</b> d’un cercle de vision (depuis ton replay).
-            </p>
+            <div>
+              <label className="text-xs text-slate-400 block mb-1">Type de tour à calibrer</label>
+              <select
+                className="w-full bg-slate-700 text-sm rounded-xl px-2 py-1"
+                value={towerCalibType}
+                onChange={(e) => setTowerCalibType(e.target.value)}
+              >
+                {Object.entries(towerTypeLabels).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+              <p className="text-xs text-slate-400 mt-1">
+                Clique <b>centre</b> puis <b>bord</b> d’un cercle de vision (depuis ton replay).
+              </p>
+            </div>
 
             <div className="h-px bg-slate-700 my-3" />
             <div className="text-sm uppercase tracking-wide text-slate-400">Ajustement manuel</div>
-            <label className="text-xs text-slate-400">Rayon tour: {towerVisionRadius}px</label>
-            <input
-              type="range"
-              min="300"
-              max="1200"
-              value={towerVisionRadius}
-              onChange={(e) => setTowerVisionRadius(+e.target.value)}
-              disabled={useOfficialRadii}
-            />
+            {Object.entries(towerTypeLabels).map(([value, label]) => (
+              <div key={value}>
+                <label className="text-xs text-slate-400">
+                  {label}: {towerVisionRadius[value] ?? 0}px
+                </label>
+                <input
+                  type="range"
+                  min="300"
+                  max="1200"
+                  value={towerVisionRadius[value] ?? 0}
+                  onChange={(e) =>
+                    setTowerVisionRadius((r) => ({ ...r, [value]: +e.target.value }))
+                  }
+                  disabled={useOfficialRadii}
+                />
+              </div>
+            ))}
             <label className="text-xs text-slate-400">Rayon joueur: {tokenVisionRadius}px</label>
             <input
               type="range"

--- a/lol-board/src/config/constants.js
+++ b/lol-board/src/config/constants.js
@@ -10,6 +10,19 @@ export const OFFICIAL_UNITS = {
 };
 
 export const wardRadiusDefault = { stealth: 260, control: 300, trap: 220 };
-export const DEFAULT_TOWER_RADIUS = 750;
+
+export const OFFICIAL_TOWER_UNITS = {
+  outer: 775,
+  inner: 800,
+  inhibitor: 850,
+  nexus: 875,
+};
+
+export const TOWER_TYPE_LABELS = {
+  outer: "Tour extérieure (T1)",
+  inner: "Tour intermédiaire (T2)",
+  inhibitor: "Tour inhibiteur (T3)",
+  nexus: "Tour du Nexus",
+};
 
 export const unitsToPx = (units, boardSize) => (boardSize * units) / OFFICIAL_UNITS.mapWidth;

--- a/lol-board/src/hooks/useFogEngine.js
+++ b/lol-board/src/hooks/useFogEngine.js
@@ -255,10 +255,22 @@ const useFogEngine = ({
     };
 
     // Tours actives
+    const towerRadiusFor = (towerId) => {
+      if (!towerVisionRadius) return 0;
+      if (towerId.includes("_t1_")) return towerVisionRadius.outer;
+      if (towerId.includes("_t2_")) return towerVisionRadius.inner;
+      if (towerId.includes("_t3_") || towerId.includes("_inhib_"))
+        return towerVisionRadius.inhibitor;
+      if (towerId.includes("nexus")) return towerVisionRadius.nexus;
+      return towerVisionRadius.outer;
+    };
+
     towers
       .filter((t) => t.team === visionSide && t.enabled)
       .forEach((t) => {
-        revealFOV(t.x * boardSize, t.y * boardSize, towerVisionRadius, {
+        const radius = towerRadiusFor(t.id);
+        if (!radius) return;
+        revealFOV(t.x * boardSize, t.y * boardSize, radius, {
           sourceTeam: visionSide,
         });
       });


### PR DESCRIPTION
## Summary
- add official tower-unit references and labels for each tower tier
- enable selecting and calibrating individual tower types with manual sliders in the control panel
- update the fog engine to apply tiered tower radii and persist them in exported state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4ef96966c8323b8e929bd2218f0a8