### PR TITLE
Fix blank screen when adjusting tower vision ranges

### DIFF
--- a/lol-board/src/App.jsx
+++ b/lol-board/src/App.jsx
@@ -56,6 +56,7 @@ export default function TacticalBoard() {
   const [wardRadius, setWardRadius] = useState(wardRadiusDefault);
   const [controlTruePx, setControlTruePx] = useState(45);
   const [useOfficialRadii, setUseOfficialRadii] = useState(true);
+  const [unitMultiplier, setUnitMultiplier] = useState(1);
 
   const [towerCalibType, setTowerCalibType] = useState("outer");
 
@@ -99,7 +100,7 @@ export default function TacticalBoard() {
     setWardRadius((r) => ({ ...r, stealth: wardPx, control: wardPx }));
     setControlTruePx(ctrlPx);
     setTowerVisionRadius(createTowerRadii(boardSize));
-  }, [boardSize, useOfficialRadii]);
+  }, [boardSize, useOfficialRadii, unitMultiplier]);
 
   const { fogCanvasRef, isVisibleOnCurrentFog, inBrushArea, allyRevealsBush } = useFogEngine({
     boardSize,


### PR DESCRIPTION
## Summary
- add missing unit multiplier state to prevent the App component from throwing when computing official radii
- rerun the official radius effect when the unit multiplier changes so recalibration updates derived values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4fef4cf008323818a17fffa167a44